### PR TITLE
Rescan only when there are UTXOs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,6 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# Mac OS files
+.DS_Store

--- a/coldcore
+++ b/coldcore
@@ -1196,21 +1196,22 @@ def run_setup(config, controller) -> t.Tuple[t.Any, t.Any]:
     bal_count = yellow(bold(f"{len(unspents)} UTXOs"))
     blank(f"found an existing balance of {yellow(bal_str)} across {yellow(bal_count)}")
 
-    rescan_begin_height = min([i["height"] for i in unspents])
-    p()
-    blank(
-        f"beginning chain rescan from height {bold(str(rescan_begin_height))} "
-        f"(minutes to hours)"
-    )
-    blank("  this allows us to find transactions associated with your coins")
-    rescan_thread = threading.Thread(
-        target=_run_rescan,
-        args=(config.rpc(wallet), rescan_begin_height),
-        daemon=True,
-    )
-    rescan_thread.start()
+    if unspents:
+        rescan_begin_height = min([i["height"] for i in unspents])
+        p()
+        blank(
+            f"beginning chain rescan from height {bold(str(rescan_begin_height))} "
+            f"(minutes to hours)"
+        )
+        blank("  this allows us to find transactions associated with your coins")
+        rescan_thread = threading.Thread(
+            target=_run_rescan,
+            args=(config.rpc(wallet), rescan_begin_height),
+            daemon=True,
+        )
+        rescan_thread.start()
 
-    time.sleep(2)
+        time.sleep(2)
 
     scan_info = rpcw.getwalletinfo()["scanning"]
     while scan_info:

--- a/src/coldcore/ui.py
+++ b/src/coldcore/ui.py
@@ -437,21 +437,22 @@ def run_setup(config, controller) -> t.Tuple[t.Any, t.Any]:
     bal_count = yellow(bold(f"{len(unspents)} UTXOs"))
     blank(f"found an existing balance of {yellow(bal_str)} across {yellow(bal_count)}")
 
-    rescan_begin_height = min([i["height"] for i in unspents])
-    p()
-    blank(
-        f"beginning chain rescan from height {bold(str(rescan_begin_height))} "
-        f"(minutes to hours)"
-    )
-    blank("  this allows us to find transactions associated with your coins")
-    rescan_thread = threading.Thread(
-        target=_run_rescan,
-        args=(config.rpc(wallet), rescan_begin_height),
-        daemon=True,
-    )
-    rescan_thread.start()
+    if unspents:
+        rescan_begin_height = min([i["height"] for i in unspents])
+        p()
+        blank(
+            f"beginning chain rescan from height {bold(str(rescan_begin_height))} "
+            f"(minutes to hours)"
+        )
+        blank("  this allows us to find transactions associated with your coins")
+        rescan_thread = threading.Thread(
+            target=_run_rescan,
+            args=(config.rpc(wallet), rescan_begin_height),
+            daemon=True,
+        )
+        rescan_thread.start()
 
-    time.sleep(2)
+        time.sleep(2)
 
     scan_info = rpcw.getwalletinfo()["scanning"]
     while scan_info:


### PR DESCRIPTION
This PR fixes a bug where if there are no UTXOs, an empty string is passed to `min`, which causes a `ValueError`. I've added a check to ensure `unspents` has a value before attempting to rescan.